### PR TITLE
Fix bug enabled merge pullrequest button when user leaves comment

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Disable to merge WIP PR on GitHub",
-  "version": "0.2",
+  "version": "0.3",
   "manifest_version": 2,
   "description": "Disable Merge pull request Button when PR is WIP on GitHub.",
   

--- a/myscript.js
+++ b/myscript.js
@@ -20,7 +20,7 @@ function observeMergeButton() {
 
   var observer = new MutationObserver(function(mutations, self) {
     mutations.forEach(function(mutation) {
-      if (mutation.type === 'characterData') {
+      if (mutation.type === 'characterData' || mutation.type === 'childList') {
         var elements = document.querySelectorAll('.merge-branch-action');
         Array.prototype.forEach.call(elements, function(element) {
           toggleMergeButton(element);


### PR DESCRIPTION
It closes https://github.com/hmatsuda/disable-merging-wip-pull-request-on-github/issues/4.
